### PR TITLE
Add token ignore functionality

### DIFF
--- a/file_upload/token_counter/token_counter.py
+++ b/file_upload/token_counter/token_counter.py
@@ -2,8 +2,10 @@ import os
 import sys
 import esprima
 import tiktoken
+import tempfile
 
 # --- Config ---
+IGNORE_DECORATOR = "//@token-ignore"
 ENCODING = "cl100k_base"
 ESPRIMA_OPTIONS = {
     "comment": False,
@@ -19,6 +21,37 @@ def read_file(file_path):
         raise FileNotFoundError(f"Error: File not found: {file_path}")
     with open(file_path, "r", encoding="utf-8") as file:
         return file.read()
+
+
+# --- Temporary File Creation ---
+# This function creates a temporary JavaScript file excluding lines marked with the ignore decorator.
+def create_temp_ignored_file(code):
+    lines = code.splitlines()
+    filtered_lines = []
+    ignoring = False
+
+    for line in lines:
+        stripped = line.strip()
+
+        if stripped.startswith(IGNORE_DECORATOR):
+            ignoring = True
+            continue
+
+        if ignoring:
+            # Stop ignoring when blank line is found
+            if stripped == "":
+                ignoring = False
+            
+            continue
+
+        filtered_lines.append(line)
+
+    # Create temporary file
+    temp_file = tempfile.NamedTemporaryFile(delete=False, suffix=".js", mode="w", encoding="utf-8")
+    temp_file.write("\n".join(filtered_lines))
+    temp_file.close()
+
+    return temp_file.name
 
 
 # --- Token Counting ---
@@ -47,7 +80,14 @@ def count_tokens(javascript_code):
 
 def tokenize_file(file_path):
     code = read_file(file_path)
-    return count_tokens(code)
+    temp_file = create_temp_ignored_file(code)
+
+    try:
+        filtered_code = read_file(temp_file)
+        return count_tokens(filtered_code)
+    finally:
+        if os.path.exists(temp_file):
+            os.remove(temp_file)
 
 
 # --- Entry Point ---


### PR DESCRIPTION
//@token-ignore now ignores lines of code up until a blank line, the lines get excluded from the tokenizers

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Token counter now supports marking code sections to exclude them from token counting using a decorator marker.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->